### PR TITLE
Vitest - Add multiSearch, deleteTag, insertTag methods

### DIFF
--- a/src/services/database.service.ts
+++ b/src/services/database.service.ts
@@ -7,6 +7,8 @@ export default class DatabaseService {
 		this.prisma = prisma;
 	}
 
+	// Post methods
+
 	async getPostById(params: { postId: number; withContent: boolean }): Promise<
 		{ post?: Post | null; errorCode?: string } |
 		{ post?: Omit<Post, "content"> | null; errorCode?: string }
@@ -124,4 +126,42 @@ export default class DatabaseService {
 			return { post: null, errorCode: "critical_error" };
 		}
 	}
-};
+
+	// Tag methods
+
+	async insertTag(params: { title: string }): Promise<{ tag?: Tag | null; errorCode?: string }> {
+		try {
+			const tag = await this.prisma.tag.create({
+				data: {
+					title: params.title,
+				},
+				select: {
+					id: true,
+					title: true,
+				}
+			})
+			return { tag };
+		} catch (err) {
+			logger.error(`Error inserting tag with title ${params.title}:`, err);
+			return { tag: null, errorCode: "critical_error" };
+		}
+	}
+
+	async deleteTag(params: { tagId: number }): Promise<{ tag?: Tag | null, errorCode?: string }> {
+		try {
+			const tag = await this.prisma.tag.delete({
+				where: {
+					id: params.tagId,
+				},
+				select: {
+					id: true,
+					title: true,
+				}
+			});
+			return { tag };
+		} catch (err) {
+			logger.error(`Error deleting tag with ID ${params.tagId}:`, err);
+			return { tag: null, errorCode: "critical_error" };
+		}
+	}
+}

--- a/tests/unit/post.test.ts
+++ b/tests/unit/post.test.ts
@@ -39,7 +39,7 @@ describe(`getPostById`, () => {
 	}
 
 	beforeEach(() => {
-		vi.clearAllMocks();
+		vi.resetAllMocks();
 	});
 
 	test(`Should return post`, async () => {

--- a/tests/unit/search.test.ts
+++ b/tests/unit/search.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import DbService from '../../src/services/database.service';
+import { PrismaClient } from '@prisma/client/extension';
+
+const prismaMock = { // Define a mock for PrismaClient
+    post: {
+        findMany: vi.fn(),
+    },
+    tag: {
+        findMany: vi.fn(),
+    }
+} as PrismaClient;
+
+const db = new DbService(prismaMock);
+
+describe("multiSearch", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    test("multiSearch via keyword", async () => {
+        const post1 = {
+            id: 1,
+            title: "Post about Typescript",
+            tags: [
+                { id: 1, title: "tag1" },
+                { id: 2, title: "someTag" }
+            ],
+            published: true,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        }
+        const tag1 = {
+            id: 1,
+            tag: "TypeScript",
+        }
+        const expectedResult = {
+            searchResult: {
+                posts: [
+                    post1,
+                ],
+                tags: [
+                    tag1,
+                ]
+            }
+        }
+
+        prismaMock.post.findMany.mockResolvedValue(expectedResult.searchResult.posts);
+        prismaMock.tag.findMany.mockResolvedValue(expectedResult.searchResult.tags);
+
+        const result = await db.multiSearch({ keyword: "typescript" });
+
+        expect(prismaMock.post.findMany).toHaveBeenCalledWith({
+            where: {
+                title: {
+                    contains: "typescript",
+                    mode: "insensitive"
+                },
+                published: true,
+            }
+        });
+        expect(prismaMock.tag.findMany).toHaveBeenCalledWith({
+            where: {
+                title: {
+                    contains: "typescript",
+                    mode: "insensitive",
+                }
+            }
+        });
+
+        expect(result).toEqual(expectedResult);
+    });
+    test("multiSearch via tag", async () => {
+        const expectedResult = {
+            searchResult: {
+                posts: [{
+                    id: 1,
+                    title: "Post about Typescript",
+                    tags: [
+                        { id: 1, title: "tag1" },
+                        { id: 2, title: "python" }
+                    ],
+                    published: true,
+                    createdAt: new Date(),
+                    updatedAt: new Date(),
+                }],
+                tags: [],
+            }
+        }
+
+        prismaMock.post.findMany.mockResolvedValue(expectedResult.searchResult.posts);
+        const result = await db.multiSearch({ tagId: 1 });
+
+        expect(result).toEqual(expectedResult);
+        expect(prismaMock.post.findMany).toHaveBeenCalledWith({
+            where: {
+                tags: {
+                    some: {
+                        id: 1,
+                    }
+                },
+                published: true,
+            }
+        });
+    });
+    //add test that handles for doubles
+});

--- a/tests/unit/tag.test.ts
+++ b/tests/unit/tag.test.ts
@@ -14,7 +14,7 @@ const db = new DbService(prismaMock);
 
 describe(`insertTag`, async () => {
     beforeEach(() => {
-        vi.clearAllMocks();
+        vi.resetAllMocks();
     });
 
     test(`Should insert a tag`, async () => {

--- a/tests/unit/tag.test.ts
+++ b/tests/unit/tag.test.ts
@@ -1,3 +1,71 @@
 import { describe, expect, test, vi, beforeEach } from 'vitest';
-import { Prisma } from "@prisma/client"; // Read about correct import method on prisma website
+import DbService from '../../src/services/database.service';
+import { PrismaClient } from '@prisma/client/extension';
 
+const prismaMock = {
+    tag: {
+        create: vi.fn(),
+        findUnique: vi.fn(),
+        delete: vi.fn(),
+    }
+} as PrismaClient;
+
+const db = new DbService(prismaMock);
+
+describe(`insertTag`, async () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    test(`Should insert a tag`, async () => {
+        const tag1 = {
+            id: 1,
+            title: "tag1",
+        }
+        prismaMock.tag.create.mockResolvedValue(tag1);
+
+
+        const result = await db.insertTag({ title: "tag1" });
+
+        expect(result).toEqual({ tag: tag1 });
+        expect(prismaMock.tag.create).toHaveBeenCalledWith({
+            data: {
+                title: "tag1",
+            },
+            select: {
+                id: true,
+                title: true,
+            }
+        });
+    });
+});
+
+describe(`deleteTag`, async () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+
+    test("Should return deleted tag", async () => {
+        const tag1 = {
+            id: 1,
+            title: "tag1",
+        }
+
+        prismaMock.tag.delete.mockResolvedValue(tag1);
+
+        const result = await db.deleteTag({ tagId: 1 });
+
+        expect(result).toEqual({ tag: tag1 });
+
+        expect(prismaMock.tag.delete).toHaveBeenCalledWith({
+            where: {
+                id: tag1.id,
+            },
+            select: {
+                id: true,
+                title: true,
+            }
+        });
+    });
+});


### PR DESCRIPTION
Added methods for tags and multiSearch. Changed clearing mocks to vi.resetAllMocks, which is better in my case.